### PR TITLE
Licence clarification

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ FTP Interface to Rackspace Cloud Files and OpenStack Swift
 
 :Homepage:  http://blog.chmouel.com/2009/10/29/ftp-server-for-cloud-files/
 :Credits:   Copyright 2009--2011 Chmouel Boudjnah <chmouel@chmouel.com>
-:Licence:   BSD
+:Licence:   MIT
 
 
 DESCRIPTION
@@ -115,6 +115,8 @@ exceptions contain licensing information in them.
 
 .. _`MIT`: http://en.wikipedia.org/wiki/MIT_License
 
+  Copyright (C) 2009-2011 Chmouel Boudjnah <chmouel@chmouel.com>
+
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal
   in the Software without restriction, including without limitation the rights
@@ -145,5 +147,6 @@ Chmouel Boudjnah <chmouel@chmouel.com>
 Contributors
 ============
 
-Nick Craig-Wood <nick@craig-wood.com>
-Juan J. Martinez <juan@memset.com>
+- Nick Craig-Wood <nick@craig-wood.com>
+- Juan J. Martinez <juan@memset.com>
+

--- a/ftpcloudfs.conf.example
+++ b/ftpcloudfs.conf.example
@@ -7,7 +7,7 @@
 # banner = Rackspace Cloud Files %v using pyftpdlib %f ready.
 
 # Port to bind.
-# port = 2022
+# port = 2021
 
 # Address to bind.
 # bind-address = 127.0.0.1

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(name='ftp-cloudfs',
         'Programming Language :: Python',
         'Operating System :: OS Independent',
         'Environment :: No Input/Output (Daemon)',
-        'License :: OSI Approved :: BSD License',
+        'License :: OSI Approved :: MIT License',
         ],
       test_suite = "nose.collector",
       )


### PR DESCRIPTION
Related to issue #7.

Because the licence text included in the README.rst file is a MIT/X11 form, I removed BSD mentions in README.rst/setup.py files.

I think now is pretty clear.

Thanks!

PS: included a fix in the configutation example ;)
