### PR TITLE
X-Forwarded-For headers

### DIFF
--- a/ftpcloudfs/fs.py
+++ b/ftpcloudfs/fs.py
@@ -13,6 +13,7 @@ import sys
 import logging
 from errno import EPERM, ENOENT, EACCES, ENOTEMPTY, ENOTDIR, EIO
 import cloudfiles
+from cloudfiles import Connection
 from chunkobject import ChunkObject
 from errors import IOSError
 import posixpath
@@ -20,6 +21,21 @@ from constants import cloudfiles_api_timeout
 from functools import wraps
 
 __all__ = ['CloudFilesFS']
+
+class ProxyConnection(Connection):
+    """
+    Add X-Forwarded-For header to all requests.
+    """
+    def __init__(self, *args, **kwargs):
+        self.real_ip = None
+        super(ProxyConnection, self).__init__(*args, **kwargs)
+
+    def make_request(self, method, path=[], data='', hdrs=None, parms=None):
+        headers = None
+        if self.real_ip:
+            headers = { 'X-Forwarded-For': self.real_ip }
+            isinstance(hdrs, dict) and headers.update(hdrs)
+        return super(ProxyConnection, self).make_request(method, path, data, headers, parms)
 
 def translate_cloudfiles_error(fn):
     """
@@ -308,7 +324,7 @@ class CloudFilesFS(object):
         # compatibility with old python api versions
         if self.authurl:
             kwargs['authurl'] = self.authurl
-        self.connection = cloudfiles.get_connection(username, api_key, timeout=30, **kwargs)
+        self.connection = ProxyConnection(username, api_key, timeout=30, **kwargs)
 
     def close(self):
         '''Dummy function which does nothing - no need to close'''

--- a/ftpcloudfs/fs.py
+++ b/ftpcloudfs/fs.py
@@ -31,11 +31,11 @@ class ProxyConnection(Connection):
         super(ProxyConnection, self).__init__(*args, **kwargs)
 
     def make_request(self, method, path=[], data='', hdrs=None, parms=None):
-        headers = None
         if self.real_ip:
-            headers = { 'X-Forwarded-For': self.real_ip }
-            isinstance(hdrs, dict) and headers.update(hdrs)
-        return super(ProxyConnection, self).make_request(method, path, data, headers, parms)
+            if not hdrs:
+                hdrs = {}
+            hdrs['X-Forwarded-For'] = self.real_ip
+        return super(ProxyConnection, self).make_request(method, path, data, hdrs, parms)
 
 def translate_cloudfiles_error(fn):
     """

--- a/ftpcloudfs/monkeypatching.py
+++ b/ftpcloudfs/monkeypatching.py
@@ -40,6 +40,7 @@ class MyFTPHandler(ftpserver.FTPHandler):
         '''Flush the FS cache with every new FTP command'''
         if self.fs:
             self.fs.flush()
+            self.fs.connection.real_ip = self.remote_ip
         super(MyFTPHandler, self).process_command(cmd, *args, **kwargs)
 
     def ftp_MD5(self, path):


### PR DESCRIPTION
ftp-cloudfs is a proxy service that allows access to Rackspace Cloud Files and Open Stack Storage Object using FTP protocol.

This simple patch adds the X-Forwarded-For header to HTTP API calls so the client address in the FTP session gets properly logged in the Swift proxy server.
