### PR TITLE
error in debian build: missing author and timestamp info in debian/changelog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -6,6 +6,8 @@ ftp-cloudfs (0.11-1)  unstable; urgency=low
    - improved logging
    - handle SSL errors
 
+ -- Juan J. Martinez <jjm@usebox.net>  Tue, 3 Jan 2012 13:36:49 +0000
+
 ftp-cloudfs (0.10-1)  unstable; urgency=low
 
   - Packages fixes


### PR DESCRIPTION
Hi there,
I tried to build the debian package but it failed because the author/timestamp info for the latest release was missing from the changelog. I added the information based on the output from `git blame debian/changelog`.
