### PR TITLE
Shared cache for multiple worker operation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,7 @@ REQUIREMENT
 - python-cloudfiles >= 1.3.0  - http://github.com/rackspace/python-cloudfiles
 - pyftpdlib >= 0.6.0 - http://code.google.com/p/pyftpdlib/
 - python-daemon >= 1.6 - http://pypi.python.org/pypi/python-daemon/
+- python-memcache >= 1.45 - http://www.tummy.com/Community/software/python-memcached/
 
 Operating Systems
 =================
@@ -58,6 +59,7 @@ which will install ftp-cloudfs with all the dependencies needed.
 On a Debian/Ubuntu the preferred way to install would be like this::
 
   apt-get -y install python-daemon python-stdeb
+  pypi-install python-memcache
   pypi-install python-cloudfiles
   pypi-install pyftpdlib
   pypi-install ftp-cloudfs
@@ -77,6 +79,7 @@ Usage: ftpcloudfs [OPTIONS].....
   -b BIND_ADDRESS, --bind-address=BIND_ADDRESS
                         Address to bind by default: 127.0.0.1.
   --workers=WORKERS     Number of workers to use default: 1.
+  --memcache=MEMCACHE   Memcache server(s) to be used for cache (ip:port).
   -a AUTHURL, --auth-url=AUTHURL
                         Auth URL for alternate providers(eg OpenStack)
   -v, --verbose         Be verbose on logging.
@@ -91,6 +94,20 @@ Usage: ftpcloudfs [OPTIONS].....
 
 The defaults can be changed using a configuration file (by default in
 /etc/ftpcloudfs.conf). Check the example file included in the package.
+
+CACHE MANAGEMENT
+================
+
+Both `Rackspace Cloud Files`_ or to `OpenStack Swift`_ are a object storages
+and not real file systems. This proxy simulates enough file system functionality
+to be used over FTP, but it has a performance hit.
+
+To improve the performance we use a cache, that can be local or external (with
+Memcache). By default a local cache is used, unless one or more Memcache servers
+are configured.
+
+If you're using just one worker the local cache will be fine, but if you're using
+several workers, adding an external cache is highly recommended.
 
 SUPPORT
 =======

--- a/README.rst
+++ b/README.rst
@@ -98,11 +98,11 @@ The defaults can be changed using a configuration file (by default in
 CACHE MANAGEMENT
 ================
 
-Both `Rackspace Cloud Files`_ or to `OpenStack Swift`_ are a object storages
+Both `Rackspace Cloud Files`_ and `OpenStack Swift`_ are a object storages
 and not real file systems. This proxy simulates enough file system functionality
 to be used over FTP, but it has a performance hit.
 
-To improve the performance we use a cache, that can be local or external (with
+To improve the performance a cache is used. It can be local or external (with
 Memcache). By default a local cache is used, unless one or more Memcache servers
 are configured.
 

--- a/README.rst
+++ b/README.rst
@@ -107,7 +107,7 @@ Memcache). By default a local cache is used, unless one or more Memcache servers
 are configured.
 
 If you're using just one worker the local cache will be fine, but if you're using
-several workers, adding an external cache is highly recommended.
+several workers, configuring an external cache is highly recommended.
 
 SUPPORT
 =======

--- a/ftpcloudfs.conf.example
+++ b/ftpcloudfs.conf.example
@@ -17,6 +17,10 @@
 # cores and the expected load.
 # workers = 1
 
+# Memcache server(s) for external cache (eg 127.0.0.1:11211)
+# Can be a comma-separated list.
+# memcache = (empty)
+
 # Maximum number of client connections per IP
 # default is 0 (no limit)
 # max-cons-per-ip = 0

--- a/ftpcloudfs/main.py
+++ b/ftpcloudfs/main.py
@@ -96,6 +96,7 @@ class Main(object):
                                   'port': default_port,
                                   'bind-address': default_address,
                                   'workers': default_workers,
+                                  'memcache': None,
                                   'max-cons-per-ip': '0',
                                   'auth-url': None,
                                   'service-net': 'no',
@@ -136,6 +137,13 @@ class Main(object):
                           default=self.config.get('ftpcloudfs', 'workers'),
                           help="Number of workers to use default: %d." % \
                               (default_workers))
+
+        parser.add_option('--memcache',
+                          type="str",
+                          dest="memcache",
+                          action="append",
+                          default=self.config.get('ftpcloudfs', 'memcache'),
+                          help="Memcache server(s) to be used for cache (ip:port).")
 
         parser.add_option('-a', '--auth-url',
                           type="str",
@@ -207,6 +215,9 @@ class Main(object):
         MyFTPHandler.banner = banner
         RackspaceCloudFilesFS.servicenet = self.options.servicenet
         RackspaceCloudFilesFS.authurl = self.options.authurl
+        RackspaceCloudFilesFS.memcache_hosts = self.options.memcache
+        if self.options.workers > 1 and not self.options.memcache:
+            RackspaceCloudFilesFS.single_cache = False
 
         masquerade = self.config.get('ftpcloudfs', 'masquerade-firewall')
         if masquerade:

--- a/ftpcloudfs/main.py
+++ b/ftpcloudfs/main.py
@@ -140,7 +140,7 @@ class Main(object):
 
         memcache = self.config.get('ftpcloudfs', 'memcache')
         if memcache:
-            memcache = tuple(x.strip() for x in memcache.split(','))
+            memcache = [x.strip() for x in memcache.split(',')]
         parser.add_option('--memcache',
                           type="str",
                           dest="memcache",

--- a/ftpcloudfs/main.py
+++ b/ftpcloudfs/main.py
@@ -138,11 +138,14 @@ class Main(object):
                           help="Number of workers to use default: %d." % \
                               (default_workers))
 
+        memcache = self.config.get('ftpcloudfs', 'memcache')
+        if memcache:
+            memcache = tuple(x.strip() for x in memcache.split(','))
         parser.add_option('--memcache',
                           type="str",
                           dest="memcache",
                           action="append",
-                          default=self.config.get('ftpcloudfs', 'memcache'),
+                          default=memcache,
                           help="Memcache server(s) to be used for cache (ip:port).")
 
         parser.add_option('-a', '--auth-url',

--- a/ftpcloudfs/monkeypatching.py
+++ b/ftpcloudfs/monkeypatching.py
@@ -39,7 +39,8 @@ class MyFTPHandler(ftpserver.FTPHandler):
     def process_command(self, cmd, *args, **kwargs):
         '''Flush the FS cache with every new FTP command'''
         if self.fs:
-            self.fs.flush()
+            if not self.fs.single_cache:
+                self.fs.flush()
             self.fs.connection.real_ip = self.remote_ip
         super(MyFTPHandler, self).process_command(cmd, *args, **kwargs)
 


### PR DESCRIPTION
Since we added the possibility of running the service using multiple workers we lost the benefit of the listing cache.

These changes improve the cache usage in different cases:
- there's just one worker: the cache works as pre-worker code (local cache)
- there are multiple workers:
  - if there's a memcached server configured, it's used to store the cache (external cache)
  - if there's no memcached server configured, the cache isn't that effective because extra flushes must be added to avoid cache insistences between workers

It adds the python-memcache dependency.
