### PR TITLE
override 10000 objects listing limit with markers

### DIFF
--- a/ftpcloudfs/fs.py
+++ b/ftpcloudfs/fs.py
@@ -221,6 +221,22 @@ class ListDirCache(object):
         else:
             prefix = None
         objects = cnt.list_objects_info(prefix=prefix, delimiter="/")
+
+        # override 10000 objects limit with markers
+        nbobjects = len(objects)
+        while nbobjects >= 10000:
+            # get last object as a marker
+            lastobject = objects[-1]
+            lastobjectname = lastobject['name']
+            # get a new list with the marker
+            newobjects = cnt.list_objects_info(prefix=prefix, delimiter="/", marker=lastobjectname)
+            # get the new list lenght
+            nbobjects = len(newobjects)
+            logging.debug("number of objects after marker %s: %s" % (lastobjectname, nbobjects))
+            # add the new list to current list
+            objects = objects + newobjects                
+        logging.debug("total number of objects %s:" % len(objects))
+
         for obj in objects:
             # {u'bytes': 4820,  u'content_type': '...',  u'hash': u'...',  u'last_modified': u'2008-11-05T00:56:00.406565',  u'name': u'new_object'},
             if 'subdir' in obj:

--- a/ftpcloudfs/fs.py
+++ b/ftpcloudfs/fs.py
@@ -230,7 +230,7 @@ class ListDirCache(object):
             lastobjectname = lastobject['name']
             # get a new list with the marker
             newobjects = cnt.list_objects_info(prefix=prefix, delimiter="/", marker=lastobjectname)
-            # get the new list lenght
+            # get the new list length
             nbobjects = len(newobjects)
             logging.debug("number of objects after marker %s: %s" % (lastobjectname, nbobjects))
             # add the new list to current list

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -28,6 +28,7 @@ class CloudFilesFSTest(unittest.TestCase):
             cls.auth_url = os.environ.get('RCLOUD_AUTH_URL')
             cls.cnx = CloudFilesFS(self.username, self.api_key, authurl=self.auth_url)
             cls.conn = cloudfiles.get_connection(self.username, self.api_key, authurl=self.auth_url)
+            cls.directconn = Connection(self.username, self.api_key, authurl=self.auth_url)
         self.cnx.mkdir("/ftpcloudfs_testing")
         self.cnx.chdir("/ftpcloudfs_testing")
         self.container = self.conn.get_container('ftpcloudfs_testing')

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -7,6 +7,7 @@ import StringIO
 from datetime import datetime
 import cloudfiles
 from ftpcloudfs.fs import CloudFilesFS
+from cloudfiles.connection import Connection
 
 import logging
 #logging.getLogger().setLevel(logging.DEBUG)
@@ -140,6 +141,25 @@ class CloudFilesFSTest(unittest.TestCase):
         self.assertTrue(dt.seconds < 60)
         self.assertEqual(self.cnx.listdir("."), ["testfile.txt"])
         self.cnx.remove("testfile.txt")
+
+    def test_listdir_over_10000(self):
+        ''' list directory with more than 10000 objects'''
+        maxnbFiles = 10000
+        content_string = "."
+        nbFiles = 0
+        while nbFiles <= maxnbFiles:
+            container = self.directconn.create_container("ftpcloudfs_testing")
+            obj = container.create_object(str(nbFiles))
+            obj.content_type = "text/plain"
+            obj.write(".")
+            nbFiles = nbFiles + 1
+        dirCount = len(self.cnx.listdir("."))
+        self.assertEqual(dirCount, maxnbFiles + 1)
+        nbFiles = 0
+        while nbFiles <= maxnbFiles:
+            container.delete_object(str(nbFiles))
+            nbFiles = nbFiles + 1
+        self.assertEqual(self.cnx.listdir("."), [])
 
     def test_listdir_subdir(self):
         ''' list a sub directory'''


### PR DESCRIPTION
Hi,

One of our users is reaching the "10000 get response" limit when listing a container.
This patch overrides this limit using markers.

Note: the patch is working for us and works with sftpcloudfs as well.

Christophe
