### PR TITLE
Iterate over keys of multiprocessing Manager, instead itself.

### DIFF
--- a/ftpcloudfs/monkeypatching.py
+++ b/ftpcloudfs/monkeypatching.py
@@ -79,7 +79,7 @@ class MyFTPHandler(ftpserver.FTPHandler):
     def close(self):
         """Remove the ip from the shared map before calling close"""
         if not self._closed and self.server.max_cons_per_ip and self.shared_ip_map != None:
-            if self.remote_ip in self.shared_ip_map:
+            if self.remote_ip in self.shared_ip_map.keys():
                 try:
                     self.shared_lock.acquire()
                     self.shared_ip_map[self.remote_ip] -= 1


### PR DESCRIPTION
See http://bugs.python.org/issue9733
and strange trace:

```
2012-08-29 18:19:15,042 - ERROR - ftpcloudfs[1251]: Traceback (most recent call last):
  File "/usr/lib/pymodules/python2.6/pyftpdlib/ftpserver.py", line 3812, in handle_accept
    handler.handle_error()
  File "/usr/lib/pymodules/python2.6/pyftpdlib/ftpserver.py", line 2339, in handle_error
    self.close()
  File "/usr/lib/pymodules/python2.6/ftpcloudfs/monkeypatching.py", line 82, in close
    if self.remote_ip in self.shared_ip_map:
  File "", line 2, in __contains__
  File "/usr/lib/python2.6/multiprocessing/managers.py", line 740, in _callmethod
    raise convert_to_error(kind, result)
RemoteError:
---------------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.6/multiprocessing/managers.py", line 216, in serve_client
    obj, exposed, gettypeid = id_to_obj[ident]
KeyError: '7fd358003a00'
```
