### PR TITLE
Fixed raise ResponseError.

### DIFF
--- a/ftpcloudfs/fs.py
+++ b/ftpcloudfs/fs.py
@@ -51,7 +51,7 @@ class ProxyConnection(Connection):
                 retry -= 1
                 logging.debug("%s, retrying (%s)" % (e, retry))
                 if retry < 0:
-                    raise cloudfiles.errors.ResponseError(e)
+                    raise cloudfiles.errors.ResponseError(500, e)
 
 def translate_cloudfiles_error(fn):
     """


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/lib/python2.6/asyncore.py", line 76, in read
    obj.handle_read_event()
  File "/usr/lib/python2.6/asyncore.py", line 416, in handle_read_event
    self.handle_read()
  File "/usr/lib/python2.6/asynchat.py", line 158, in handle_read
    self.found_terminator()
  File "/usr/lib/pymodules/python2.6/pyftpdlib/ftpserver.py", line 2286, in found_terminator
    self.process_command(cmd, arg, **kwargs)
  File "/usr/lib/pymodules/python2.6/ftpcloudfs/monkeypatching.py", line 45, in process_command
    super(MyFTPHandler, self).process_command(cmd, *args, **kwargs)
  File "/usr/lib/pymodules/python2.6/pyftpdlib/ftpserver.py", line 2295, in process_command
    method(*args, **kwargs)
  File "/usr/lib/pymodules/python2.6/pyftpdlib/ftpserver.py", line 3375, in ftp_RNTO
    self.run_as_current_user(self.fs.rename, src, path)
  File "/usr/lib/pymodules/python2.6/pyftpdlib/ftpserver.py", line 2551, in run_as_current_user
    return function(*args, **kwargs)
  File "/usr/lib/pymodules/python2.6/ftpcloudfs/fs.py", line 67, in wrapper
    return fn(*args, **kwargs)
  File "/usr/lib/pymodules/python2.6/ftpcloudfs/fs.py", line 603, in rename
    src_obj.copy_to(dst_container_name, dst_path)
  File "/usr/lib/pymodules/python2.6/cloudfiles/utils.py", line 45, in decorator
    return f(*args, **kwargs)
  File "/usr/lib/pymodules/python2.6/cloudfiles/storage_object.py", line 394, in copy_to
    'COPY', [self.container.name, self.name], hdrs=headers, data='')
  File "/usr/lib/pymodules/python2.6/ftpcloudfs/fs.py", line 54, in make_request
    raise cloudfiles.errors.ResponseError(e)
TypeError: __init__() takes exactly 3 arguments (2 given)
```
